### PR TITLE
Add workflow dependency for CICD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,10 @@
 name: CD
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches: [main]
 
 concurrency:
@@ -21,6 +24,7 @@ jobs:
   # ── Detect which services changed (same filter as CI) ─────────────────────
   changes:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     outputs:
       question:      ${{ steps.filter.outputs.question }}
       user:          ${{ steps.filter.outputs.user }}


### PR DESCRIPTION
# Summary 

1. Add dependency on CI for CD workflow activation. CD workflow will only run when CI workflow is completed and successful on main branch